### PR TITLE
Add support for units other than pixels

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ function SimpleColorPicker(options) {
   // properties
   this.color = null;
   this.width = 0;
+  this.widthUnits = 'px';
   this.height = 0;
+  this.heightUnits = 'px';
   this.hue = 0;
   this.choosing = false;
   this.position = {x: 0, y: 0};
@@ -66,6 +68,12 @@ function SimpleColorPicker(options) {
   }
   if (options.background) {
     this.setBackgroundColor(options.background);
+  }
+  if (options.widthUnits) {
+    this.widthUnits = options.widthUnits;
+  }
+  if (options.heightUnits) {
+    this.heightUnits = options.heightUnits;
   }
   this.setSize(options.width || 175, options.height || 150);
   this.setColor(options.color);
@@ -144,8 +152,8 @@ SimpleColorPicker.prototype.setColor = function(color) {
 SimpleColorPicker.prototype.setSize = function(width, height) {
   this.width = width;
   this.height = height;
-  this.$el.style.width = this.width + 'px';
-  this.$el.style.height = this.height + 'px';
+  this.$el.style.width = this.width + this.widthUnits;
+  this.$el.style.height = this.height + this.heightUnits;
   this.saturationWidth = this.width - 25;
   this.maxHue = this.height - 2;
   return this;

--- a/test/test.js
+++ b/test/test.js
@@ -35,6 +35,22 @@ test('SimpleColorPicker: Options sizes', function(t) {
   t.equal(colorPicker.$el.style.height, '210px', 'height option style');
 });
 
+test('SimpleColorPicker: Options units', function(t) {
+  t.plan(4);
+
+  var colorPicker = new SimpleColorPicker({
+    width: 30,
+    widthUnits: 'vw',
+    height: 10,
+    heightUnits: 'vh'
+  });
+
+  t.equal(colorPicker.width, 30, 'width option');
+  t.equal(colorPicker.height, 10, 'height option');
+  t.equal(colorPicker.$el.style.width, '30vw', 'width option style');
+  t.equal(colorPicker.$el.style.height, '10vh', 'height option style');
+});
+
 test('SimpleColorPicker: Options color', function(t) {
   t.plan(2);
 


### PR DESCRIPTION
Non-breaking change to allow for units other than pixels. The default unit of measurement remains 'px'.

A different unit of measurement for height and width can be passed in the constructor:
```js
var colorPicker = new ColorPicker({
  el: document.body,
  widthUnits: 'vw',
  width: 30,
  heightUnits: 'vh',
  height: 10
});
```