### PR TITLE
Hide selector outsite of saturation element

### DIFF
--- a/src/css/simple-color-picker.styl
+++ b/src/css/simple-color-picker.styl
@@ -9,6 +9,7 @@ pickerHueWidth = 20px
   height 100%
   background linear-gradient(to right, #FFFFFF, #FF0000);
   float left
+  overflow hidden
   margin-right 5px
 
 .Scp-brightness


### PR DESCRIPTION
I think this is a much more natural look for a color selector, but that's of course very much up to personal preference. 

Example: ![](http://i.imgur.com/n4gvfBn.png)