### PR TITLE
Fix for a bug that breaks "click and drag" on the color picker when inside an iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ var colorPicker = new ColorPicker({
   background: '#454545',
   el: document.body,
   width: 200,
-  height: 200
+  height: 200,
+  window: document.getElementsByTagName('iframe')[0].contentWindow
 });
 ```
 
-None of these options are mendatory.
+None of these options are mandatory.
 
 ### `color`
 The default color that the colorpicker will display. Default is #FFFFFF. It can be a hexadecimal number or an hex String.
@@ -53,6 +54,9 @@ Desired width of the color picker. Default is 175.
 
 ### `height`
 Desired height of the color picker. Default is 150.
+
+### `window`
+Reference to a window object. This will allow Simple Color Picker to apply event listeners in the correct context in the event that you are using it inside of an iFrame from a script that resides outside of it.
 
 ## Methods
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,8 +42,12 @@ function SimpleColorPicker(options) {
   this._onHueMouseMove = this._onHueMouseMove.bind(this);
   this._onHueMouseUp = this._onHueMouseUp.bind(this);
 
+  // Register window and document references in case this is instantiated inside of an iframe
+  this.window = options.window || window;
+  this.document = this.window.document
+
   // Create DOM
-  this.$el = document.createElement('div');
+  this.$el = this.document.createElement('div');
   this.$el.className = 'Scp';
   this.$el.innerHTML = [
     '<div class="Scp-saturation">',
@@ -328,10 +332,10 @@ SimpleColorPicker.prototype._onSaturationMouseDown = function(e) {
   var yPos = getMousePosition(e).y;
   this._moveSelectorTo(xPos - sbOffset.left, yPos - sbOffset.top);
   this._updateColorFromPosition();
-  window.addEventListener('mouseup', this._onSaturationMouseUp);
-  window.addEventListener('touchend', this._onSaturationMouseUp);
-  window.addEventListener('mousemove', this._onSaturationMouseMove);
-  window.addEventListener('touchmove', this._onSaturationMouseMove);
+  this.window.addEventListener('mouseup', this._onSaturationMouseUp);
+  this.window.addEventListener('touchend', this._onSaturationMouseUp);
+  this.window.addEventListener('mousemove', this._onSaturationMouseMove);
+  this.window.addEventListener('touchmove', this._onSaturationMouseMove);
   e.preventDefault();
 };
 
@@ -344,10 +348,10 @@ SimpleColorPicker.prototype._onSaturationMouseMove = function(e) {
 };
 
 SimpleColorPicker.prototype._onSaturationMouseUp = function() {
-  window.removeEventListener('mouseup', this._onSaturationMouseUp);
-  window.removeEventListener('touchend', this._onSaturationMouseUp);
-  window.removeEventListener('mousemove', this._onSaturationMouseMove);
-  window.removeEventListener('touchmove', this._onSaturationMouseMove);
+  this.window.removeEventListener('mouseup', this._onSaturationMouseUp);
+  this.window.removeEventListener('touchend', this._onSaturationMouseUp);
+  this.window.removeEventListener('mousemove', this._onSaturationMouseMove);
+  this.window.removeEventListener('touchmove', this._onSaturationMouseMove);
 };
 
 SimpleColorPicker.prototype._onHueMouseDown = function(e) {
@@ -355,10 +359,10 @@ SimpleColorPicker.prototype._onHueMouseDown = function(e) {
   var yPos = getMousePosition(e).y;
   this._moveHueTo(yPos - hOffset.top);
   this._updateHueFromPosition();
-  window.addEventListener('mouseup', this._onHueMouseUp);
-  window.addEventListener('touchend', this._onHueMouseUp);
-  window.addEventListener('mousemove', this._onHueMouseMove);
-  window.addEventListener('touchmove', this._onHueMouseMove);
+  this.window.addEventListener('mouseup', this._onHueMouseUp);
+  this.window.addEventListener('touchend', this._onHueMouseUp);
+  this.window.addEventListener('mousemove', this._onHueMouseMove);
+  this.window.addEventListener('touchmove', this._onHueMouseMove);
   e.preventDefault();
 };
 
@@ -370,10 +374,10 @@ SimpleColorPicker.prototype._onHueMouseMove = function(e) {
 };
 
 SimpleColorPicker.prototype._onHueMouseUp = function() {
-  window.removeEventListener('mouseup', this._onHueMouseUp);
-  window.removeEventListener('touchend', this._onHueMouseUp);
-  window.removeEventListener('mousemove', this._onHueMouseMove);
-  window.removeEventListener('touchmove', this._onHueMouseMove);
+  this.window.removeEventListener('mouseup', this._onHueMouseUp);
+  this.window.removeEventListener('touchend', this._onHueMouseUp);
+  this.window.removeEventListener('mousemove', this._onHueMouseMove);
+  this.window.removeEventListener('touchmove', this._onHueMouseMove);
 };
 
 /* =============================================================================


### PR DESCRIPTION
Hi Guillaume,

I've stumbled upon an edge case where the "click and drag" functionality in the color picker is broken.

**The circumstances**: Simple color picker is instantiated inside of an iframe from a script that resides outside of it.

**What happens**: The first click registers, but the color picker dot does not follow the user's mouse until their mouse leaves the bounding box of the iframe( and then it tries to follow the mouse without the mouse button being held down. )

**My proposed fix**: We pass in a reference to whichever window we want the event listeners bound to.

According to "npm run test", everything still passes.

Here's a demo demonstrating the broken/fixed functionality:

https://jonleckie.github.io/simple-color-picker-demo/

I've tested and confirmed both the bug and the fix in the following browsers:

- Safari ( 10.0.3 )
- Firefox ( 44.0 )
- Chrome ( 57.0.2987.54 beta )
- Edge ( 38.14393.0.0 )

Let me know if you have any questions or suggestions.

Thanks!